### PR TITLE
feat: add custom news cell with thumbnail and description

### DIFF
--- a/NewsAggregator.xcodeproj/project.pbxproj
+++ b/NewsAggregator.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		CE27ACDE2E218B7A00FECF74 /* APIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE27ACDD2E218B7A00FECF74 /* APIService.swift */; };
 		CE27ACE12E218D7E00FECF74 /* NewsArticle.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE27ACE02E218D7E00FECF74 /* NewsArticle.swift */; };
 		CE27AD042E21AC7300FECF74 /* NewsListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE27AD032E21AC7300FECF74 /* NewsListViewModel.swift */; };
+		CE27AD062E21B95200FECF74 /* NewsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE27AD052E21B95200FECF74 /* NewsTableViewCell.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -30,6 +31,7 @@
 		CE27ACDD2E218B7A00FECF74 /* APIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIService.swift; sourceTree = "<group>"; };
 		CE27ACE02E218D7E00FECF74 /* NewsArticle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsArticle.swift; sourceTree = "<group>"; };
 		CE27AD032E21AC7300FECF74 /* NewsListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsListViewModel.swift; sourceTree = "<group>"; };
+		CE27AD052E21B95200FECF74 /* NewsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsTableViewCell.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -113,6 +115,7 @@
 			children = (
 				CE27ACD92E218A3D00FECF74 /* NewsListViewController.swift */,
 				CE27AD032E21AC7300FECF74 /* NewsListViewModel.swift */,
+				CE27AD052E21B95200FECF74 /* NewsTableViewCell.swift */,
 			);
 			path = NewList;
 			sourceTree = "<group>";
@@ -215,6 +218,7 @@
 			files = (
 				CE27ACE12E218D7E00FECF74 /* NewsArticle.swift in Sources */,
 				CE27ACCC2E217F0400FECF74 /* AppDelegate.swift in Sources */,
+				CE27AD062E21B95200FECF74 /* NewsTableViewCell.swift in Sources */,
 				CE27ACCD2E217F0400FECF74 /* SceneDelegate.swift in Sources */,
 				CE27ACDC2E218B2E00FECF74 /* FavoritesViewController.swift in Sources */,
 				CE27ACDE2E218B7A00FECF74 /* APIService.swift in Sources */,

--- a/NewsAggregator/Modules/NewList/NewsListViewController.swift
+++ b/NewsAggregator/Modules/NewList/NewsListViewController.swift
@@ -20,8 +20,11 @@ class NewsListViewController: UIViewController {
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.dataSource = self
         tableView.delegate = self
-        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
+        tableView.register(NewsTableViewCell.self, forCellReuseIdentifier: NewsTableViewCell.identifier)
         
+        tableView.estimatedRowHeight = 100
+        tableView.rowHeight = UITableView.automaticDimension
+
         NSLayoutConstraint.activate([
             tableView.topAnchor.constraint(equalTo: view.topAnchor),
             tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
@@ -44,13 +47,10 @@ extension NewsListViewController: UITableViewDataSource, UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let article = viewModel.article(at: indexPath.row)
-        let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
-        
-        var content = cell.defaultContentConfiguration()
-        content.text = article.title ?? "Без названия"
-        content.secondaryText = article.pubDate
-        cell.contentConfiguration = content
-        
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: NewsTableViewCell.identifier, for: indexPath) as? NewsTableViewCell else {
+            return UITableViewCell()
+        }
+        cell.configure(with: article)
         return cell
     }
 }

--- a/NewsAggregator/Modules/NewList/NewsTableViewCell.swift
+++ b/NewsAggregator/Modules/NewList/NewsTableViewCell.swift
@@ -1,0 +1,102 @@
+import UIKit
+
+class NewsTableViewCell: UITableViewCell {
+    
+    static let identifier = "NewsTableViewCell"
+
+    private let thumbnailImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFill
+        imageView.layer.cornerRadius = 8
+        imageView.clipsToBounds = true
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.backgroundColor = .secondarySystemBackground
+        return imageView
+    }()
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.boldSystemFont(ofSize: 16)
+        label.numberOfLines = 2
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let authorLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 12)
+        label.textColor = .secondaryLabel
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let descriptionLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 14)
+        label.numberOfLines = 3
+        label.textColor = .label
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupLayout() {
+        contentView.addSubview(thumbnailImageView)
+        contentView.addSubview(titleLabel)
+        contentView.addSubview(authorLabel)
+        contentView.addSubview(descriptionLabel)
+
+        NSLayoutConstraint.activate([
+            thumbnailImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 12),
+            thumbnailImageView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 12),
+            thumbnailImageView.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor, constant: -12),
+            thumbnailImageView.widthAnchor.constraint(equalToConstant: 80),
+            thumbnailImageView.heightAnchor.constraint(equalToConstant: 80),
+
+            titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 12),
+            titleLabel.leadingAnchor.constraint(equalTo: thumbnailImageView.trailingAnchor, constant: 12),
+            titleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -12),
+
+            authorLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 4),
+            authorLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
+            authorLabel.trailingAnchor.constraint(equalTo: titleLabel.trailingAnchor),
+
+            descriptionLabel.topAnchor.constraint(equalTo: authorLabel.bottomAnchor, constant: 6),
+            descriptionLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
+            descriptionLabel.trailingAnchor.constraint(equalTo: titleLabel.trailingAnchor),
+            descriptionLabel.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor, constant: -12)
+        ])
+    }
+
+    func configure(with article: NewsArticle) {
+        titleLabel.text = article.title
+        authorLabel.text = article.creator?.first ?? "Неизвестный автор"
+        descriptionLabel.text = article.description
+
+        if let imageURLString = article.image_url,
+           let url = URL(string: imageURLString) {
+            loadImage(from: url)
+        } else {
+            thumbnailImageView.image = UIImage(systemName: "photo")
+        }
+    }
+
+    private func loadImage(from url: URL) {
+        // Простейшая загрузка изображения (без кеша)
+        URLSession.shared.dataTask(with: url) { [weak self] data, _, _ in
+            guard let data = data,
+                  let image = UIImage(data: data) else { return }
+            DispatchQueue.main.async {
+                self?.thumbnailImageView.image = image
+            }
+        }.resume()
+    }
+}


### PR DESCRIPTION
## 🧩 Что сделано

Добавлена кастомная ячейка для отображения новостей в списке:

- миниатюра изображения (`thumbnail`)
- заголовок статьи (`title`)
- имя автора (`creator`)
- краткое описание (`description`)

Также добавлена базовая верстка с `AutoLayout`.

---

## 📸 Скриншот (симулятор)



## 📸 Скриншот (симулятор)

<img src="https://github.com/user-attachments/assets/03ad6f5c-eba6-45be-80af-7f7b33899106" width="300" />


---

## 🧪 Как протестировать

1. Запустить приложение
2. Убедиться, что на экране **"Все новости"** отображаются:
   - Картинка (если есть)
   - Заголовок (bold)
   - Автор (мелкий шрифт)
   - Описание (до 3 строк)

---

## 📌 Дополнительно

- Временная загрузка изображения без кеша (добавим позже)
- Если изображения нет — отображается иконка-заглушка
- Используется `UITableView.
