### PR TITLE
feat: add favorites logic and star toggle in detail screen (closes #3)

### DIFF
--- a/NewsAggregator.xcodeproj/project.pbxproj
+++ b/NewsAggregator.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		CE27ACE12E218D7E00FECF74 /* NewsArticle.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE27ACE02E218D7E00FECF74 /* NewsArticle.swift */; };
 		CE27AD042E21AC7300FECF74 /* NewsListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE27AD032E21AC7300FECF74 /* NewsListViewModel.swift */; };
 		CE27AD062E21B95200FECF74 /* NewsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE27AD052E21B95200FECF74 /* NewsTableViewCell.swift */; };
+		CE27AD082E226A8A00FECF74 /* NewsDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE27AD072E226A8A00FECF74 /* NewsDetailViewController.swift */; };
+		CE27AD0A2E22819D00FECF74 /* FavoritesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE27AD092E22819D00FECF74 /* FavoritesManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -32,6 +34,8 @@
 		CE27ACE02E218D7E00FECF74 /* NewsArticle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsArticle.swift; sourceTree = "<group>"; };
 		CE27AD032E21AC7300FECF74 /* NewsListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsListViewModel.swift; sourceTree = "<group>"; };
 		CE27AD052E21B95200FECF74 /* NewsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsTableViewCell.swift; sourceTree = "<group>"; };
+		CE27AD072E226A8A00FECF74 /* NewsDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsDetailViewController.swift; sourceTree = "<group>"; };
+		CE27AD092E22819D00FECF74 /* FavoritesManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -91,6 +95,7 @@
 			isa = PBXGroup;
 			children = (
 				CE27ACDD2E218B7A00FECF74 /* APIService.swift */,
+				CE27AD092E22819D00FECF74 /* FavoritesManager.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -131,6 +136,7 @@
 		CE27ACD82E21894D00FECF74 /* NewsDetail */ = {
 			isa = PBXGroup;
 			children = (
+				CE27AD072E226A8A00FECF74 /* NewsDetailViewController.swift */,
 			);
 			path = NewsDetail;
 			sourceTree = "<group>";
@@ -217,11 +223,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				CE27ACE12E218D7E00FECF74 /* NewsArticle.swift in Sources */,
+				CE27AD0A2E22819D00FECF74 /* FavoritesManager.swift in Sources */,
 				CE27ACCC2E217F0400FECF74 /* AppDelegate.swift in Sources */,
 				CE27AD062E21B95200FECF74 /* NewsTableViewCell.swift in Sources */,
 				CE27ACCD2E217F0400FECF74 /* SceneDelegate.swift in Sources */,
 				CE27ACDC2E218B2E00FECF74 /* FavoritesViewController.swift in Sources */,
 				CE27ACDE2E218B7A00FECF74 /* APIService.swift in Sources */,
+				CE27AD082E226A8A00FECF74 /* NewsDetailViewController.swift in Sources */,
 				CE27AD042E21AC7300FECF74 /* NewsListViewModel.swift in Sources */,
 				CE27ACDA2E218A3D00FECF74 /* NewsListViewController.swift in Sources */,
 			);

--- a/NewsAggregator/Models/NewsArticle.swift
+++ b/NewsAggregator/Models/NewsArticle.swift
@@ -1,11 +1,11 @@
 
 import Foundation
 
-struct NewsResponse: Codable {
+struct NewsResponse: Codable{
     let results: [NewsArticle]
 }
 
-struct NewsArticle: Codable {
+struct NewsArticle: Codable, Equatable, Hashable {
     let title: String?
     let link: String?
     let pubDate: String?

--- a/NewsAggregator/Modules/NewList/NewsListViewController.swift
+++ b/NewsAggregator/Modules/NewList/NewsListViewController.swift
@@ -53,4 +53,11 @@ extension NewsListViewController: UITableViewDataSource, UITableViewDelegate {
         cell.configure(with: article)
         return cell
     }
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let article = viewModel.article(at: indexPath.row)
+        let detailVC = NewsDetailViewController(article: article)
+        navigationController?.pushViewController(detailVC, animated: true)
+        tableView.deselectRow(at: indexPath, animated: true)
+    }
 }

--- a/NewsAggregator/Modules/NewsDetail/NewsDetailViewController.swift
+++ b/NewsAggregator/Modules/NewsDetail/NewsDetailViewController.swift
@@ -1,29 +1,137 @@
-//
-//  NewsDetailViewController.swift
-//  NewsAggregator
-//
-//  Created by Baytik  on 12/7/25.
-//
-
+import SafariServices
 import UIKit
 
-class NewsDetailViewController: UIViewController {
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+final class NewsDetailViewController: UIViewController {
+    private let article: NewsArticle
+    
+    private let scrollView = UIScrollView()
+    private let stackView = UIStackView()
+    
+    private let imageView = UIImageView()
+    private let titleLabel = UILabel()
+    private let authorLabel = UILabel()
+    private let dateLabel = UILabel()
+    private let descriptionLabel = UILabel()
+    private let sourceButton = UIButton(type: .system)
+    
+    private var isFavorite: Bool = false {
+        didSet {
+            updateFavoriteIcon()
+        }
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    init(article: NewsArticle) {
+        self.article = article
+        super.init(nibName: nil, bundle: nil)
+        self.title = "Детали"
     }
-    */
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        configure()
+        isFavorite = FavoritesManager.shared.isFavorite(article)
+    }
+    
+    private func setupUI() {
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(scrollView)
 
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+
+        // ⚠️ ВАЖНО: добавляем stackView внутрь scrollView
+        stackView.axis = .vertical
+        stackView.spacing = 12
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.addSubview(stackView)
+
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: scrollView.topAnchor, constant: 16),
+            stackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor, constant: -16),
+            stackView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor, constant: 16),
+            stackView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor, constant: -16),
+            stackView.widthAnchor.constraint(equalTo: scrollView.widthAnchor, constant: -32)
+        ])
+
+        // Элементы
+        imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
+        imageView.layer.cornerRadius = 12
+        imageView.heightAnchor.constraint(equalToConstant: 200).isActive = true
+
+        titleLabel.font = UIFont.boldSystemFont(ofSize: 22)
+        titleLabel.numberOfLines = 0
+
+        authorLabel.font = UIFont.systemFont(ofSize: 14)
+        authorLabel.textColor = .secondaryLabel
+
+        dateLabel.font = UIFont.systemFont(ofSize: 13)
+        dateLabel.textColor = .secondaryLabel
+
+        descriptionLabel.font = UIFont.systemFont(ofSize: 16)
+        descriptionLabel.numberOfLines = 0
+
+        sourceButton.setTitle("Читать в источнике", for: .normal)
+        sourceButton.titleLabel?.font = UIFont.systemFont(ofSize: 16, weight: .medium)
+        sourceButton.addTarget(self, action: #selector(openSource), for: .touchUpInside)
+
+        // Добавляем в stackView
+        [imageView, titleLabel, authorLabel, dateLabel, descriptionLabel, sourceButton].forEach {
+            stackView.addArrangedSubview($0)
+        }
+        
+        // Навбар кнопка
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            image: UIImage(systemName: "star"),
+            style: .plain,
+            target: self,
+            action: #selector(toggleFavorite)
+        )
+    }
+
+    private func configure() {
+        titleLabel.text = article.title
+        authorLabel.text = "Автор: \(article.creator?.first ?? "неизвестен")"
+        dateLabel.text = article.pubDate
+        descriptionLabel.text = article.description
+        
+        if let imageURLString = article.image_url,
+           let url = URL(string: imageURLString) {
+            loadImage(from: url)
+        } else {
+            imageView.image = UIImage(systemName: "photo")
+        }
+    }
+    private func loadImage(from url: URL) {
+        URLSession.shared.dataTask(with: url) { [weak self] data , _, _ in
+            guard let data = data,
+                  let image = UIImage(data: data) else { return }
+            DispatchQueue.main.async {
+                self?.imageView.image = image
+            }
+        }.resume()
+    }
+    @objc private func openSource() {
+        guard let urlString = article.link, let url = URL(string: urlString) else { return }
+        let safariVC = SFSafariViewController(url: url)
+        present(safariVC, animated: true)
+    }
+
+    private func updateFavoriteIcon() {
+        let imageName = isFavorite ? "star.fill" : "star"
+        navigationItem.rightBarButtonItem?.image = UIImage(systemName: imageName)
+    }
+
+    @objc private func toggleFavorite() {
+        FavoritesManager.shared.toggleFavorite(article)
+        isFavorite.toggle()
+    }
 }

--- a/NewsAggregator/Services/FavoritesManager.swift
+++ b/NewsAggregator/Services/FavoritesManager.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+final class FavoritesManager {
+    static let shared = FavoritesManager()
+
+    private let key = "favoriteArticles"
+
+    private init() {}
+
+    func isFavorite(_ article: NewsArticle) -> Bool {
+        guard let saved = getFavorites() else { return false }
+        return saved.contains { $0.link == article.link }
+    }
+
+    func addToFavorites(_ article: NewsArticle) {
+        var current = getFavorites() ?? []
+        guard !current.contains(where: { $0.link == article.link }) else { return }
+        current.append(article)
+        saveFavorites(current)
+    }
+
+    func removeFromFavorites(_ article: NewsArticle) {
+        guard var current = getFavorites() else { return }
+        current.removeAll { $0.link == article.link }
+        saveFavorites(current)
+    }
+
+    func toggleFavorite(_ article: NewsArticle) {
+        if isFavorite(article) {
+            removeFromFavorites(article)
+        } else {
+            addToFavorites(article)
+        }
+    }
+
+    func getFavorites() -> [NewsArticle]? {
+        guard let data = UserDefaults.standard.data(forKey: key) else { return nil }
+        return try? JSONDecoder().decode([NewsArticle].self, from: data)
+    }
+
+    private func saveFavorites(_ articles: [NewsArticle]) {
+        if let data = try? JSONEncoder().encode(articles) {
+            UserDefaults.standard.set(data, forKey: key)
+        }
+    }
+}


### PR DESCRIPTION
## 🧩 Что сделано

Добавлена логика избранного с использованием `UserDefaults`:

- реализован `FavoritesManager` для хранения/удаления избранных новостей
- добавлена поддержка избранного в `NewsDetailViewController`
- при открытии детального экрана отображается текущее состояние избранного (звезда)
- при нажатии на звезду — состояние переключается и сохраняется

---

## ⚙️ Технические детали

- сохранение происходит через сериализацию `NewsArticle` в JSON
- уникальность определяется по `link`
- `NewsArticle` теперь реализует `Equatable` и `Hashable`
- состояние обновляется через `isFavorite` с автоматическим обновлением кнопки

---

## 🧪 Как протестировать

1. Открыть новость
2. Нажать на ⭐️ — она закрасится
3. Закрыть и открыть новость снова — ⭐️ должна быть активной
4. Нажать снова — уберётся из избранного

---

## 🔗 Связанные тикеты

Closes #3
