### PR TITLE
feat: implement favorites screen with list and detail view (closes #4)

### DIFF
--- a/NewsAggregator/Modules/Favorites/FavoritesViewController.swift
+++ b/NewsAggregator/Modules/Favorites/FavoritesViewController.swift
@@ -1,11 +1,65 @@
-
 import UIKit
 
-class FavoritesViewController: UIViewController {
+final class FavoritesViewController: UIViewController {
+
+    private let tableView = UITableView()
+    private var favorites: [NewsArticle] = []
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .systemBackground
         title = "Избранное"
+        view.backgroundColor = .systemBackground
+        setupTableView()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        loadFavorites()
+    }
+
+    private func setupTableView() {
+        view.addSubview(tableView)
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+
+        tableView.delegate = self
+        tableView.dataSource = self
+
+        tableView.register(NewsTableViewCell.self, forCellReuseIdentifier: NewsTableViewCell.identifier)
+        tableView.estimatedRowHeight = 100
+        tableView.rowHeight = UITableView.automaticDimension
+
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.topAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+    }
+
+    private func loadFavorites() {
+        favorites = FavoritesManager.shared.getFavorites() ?? []
+        tableView.reloadData()
+    }
+}
+
+extension FavoritesViewController: UITableViewDataSource, UITableViewDelegate {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        favorites.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let article = favorites[indexPath.row]
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: NewsTableViewCell.identifier, for: indexPath) as? NewsTableViewCell else {
+            return UITableViewCell()
+        }
+        cell.configure(with: article)
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let article = favorites[indexPath.row]
+        let detailVC = NewsDetailViewController(article: article)
+        navigationController?.pushViewController(detailVC, animated: true)
+        tableView.deselectRow(at: indexPath, animated: true)
     }
 }

--- a/NewsAggregator/Modules/NewList/NewsListViewController.swift
+++ b/NewsAggregator/Modules/NewList/NewsListViewController.swift
@@ -1,7 +1,7 @@
 
 import UIKit
 
-class NewsListViewController: UIViewController {
+final class NewsListViewController: UIViewController {
     
     private let tableView = UITableView()
     private let viewModel = NewsListViewModel()

--- a/NewsAggregator/Modules/NewList/NewsTableViewCell.swift
+++ b/NewsAggregator/Modules/NewList/NewsTableViewCell.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class NewsTableViewCell: UITableViewCell {
+final class NewsTableViewCell: UITableViewCell {
     
     static let identifier = "NewsTableViewCell"
 


### PR DESCRIPTION
## 🧩 Что сделано

Добавлен экран `FavoritesViewController` с отображением избранных новостей:

- подключён `FavoritesManager` для получения сохранённых статей
- использован `UITableView` с кастомной ячейкой
- при нажатии на новость открывается `NewsDetailViewController`
- данные обновляются каждый раз при появлении экрана (`viewWillAppear`)

---

---

## 📸 Скриншот

<img src="https://github.com/user-attachments/assets/35bce35c-4b1e-4641-9949-9fe450d27e82" width="300" />

---

## 🧪 Как протестировать

1. Открыть приложение
2. Перейти во вкладку **Избранное**
3. Если нет новостей — добавить из любого детального экрана (звезда)
4. Перейти обратно — новости должны появиться в списке
5. Нажать на любую — откроется экран с полной информацией

---

## 📌 Дополнительно

- Избранные подтягиваются каждый раз при входе в экран
- Используется переиспользуемая ячейка `NewsTableViewCell`
- Подготовлена навигация из избранного в детальный экран

---

## 🔗 Связанные тикеты

Closes #4
