### PR TITLE
feat: add empty state view for favorites screen (closes #7)

### DIFF
--- a/NewsAggregator.xcodeproj/project.pbxproj
+++ b/NewsAggregator.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		CE27AD082E226A8A00FECF74 /* NewsDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE27AD072E226A8A00FECF74 /* NewsDetailViewController.swift */; };
 		CE27AD0A2E22819D00FECF74 /* FavoritesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE27AD092E22819D00FECF74 /* FavoritesManager.swift */; };
 		CE27AD0C2E228CB200FECF74 /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE27AD0B2E228CB200FECF74 /* ImageLoader.swift */; };
+		CE27AD112E22DF7800FECF74 /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE27AD102E22DF7800FECF74 /* EmptyStateView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -38,6 +39,7 @@
 		CE27AD072E226A8A00FECF74 /* NewsDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsDetailViewController.swift; sourceTree = "<group>"; };
 		CE27AD092E22819D00FECF74 /* FavoritesManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesManager.swift; sourceTree = "<group>"; };
 		CE27AD0B2E228CB200FECF74 /* ImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoader.swift; sourceTree = "<group>"; };
+		CE27AD102E22DF7800FECF74 /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -164,6 +166,7 @@
 			isa = PBXGroup;
 			children = (
 				CE27AD052E21B95200FECF74 /* NewsTableViewCell.swift */,
+				CE27AD102E22DF7800FECF74 /* EmptyStateView.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -247,6 +250,7 @@
 				CE27AD062E21B95200FECF74 /* NewsTableViewCell.swift in Sources */,
 				CE27ACCD2E217F0400FECF74 /* SceneDelegate.swift in Sources */,
 				CE27AD0C2E228CB200FECF74 /* ImageLoader.swift in Sources */,
+				CE27AD112E22DF7800FECF74 /* EmptyStateView.swift in Sources */,
 				CE27ACDC2E218B2E00FECF74 /* FavoritesViewController.swift in Sources */,
 				CE27ACDE2E218B7A00FECF74 /* APIService.swift in Sources */,
 				CE27AD082E226A8A00FECF74 /* NewsDetailViewController.swift in Sources */,

--- a/NewsAggregator/Modules/Favorites/FavoritesViewController.swift
+++ b/NewsAggregator/Modules/Favorites/FavoritesViewController.swift
@@ -3,19 +3,30 @@ import UIKit
 final class FavoritesViewController: UIViewController {
 
     private let tableView = UITableView()
-    private var favorites: [NewsArticle] = []
+    private let emptyView = EmptyStateView(message: "У вас пока нет избранных новостей")
+    
+    private var favorites: [NewsArticle] = [] {
+        didSet {
+            updateUI()
+        }
+    }
+
+    // MARK: - Lifecycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "Избранное"
         view.backgroundColor = .systemBackground
         setupTableView()
+        setupEmptyView()
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         loadFavorites()
     }
+
+    // MARK: - Setup
 
     private func setupTableView() {
         view.addSubview(tableView)
@@ -36,12 +47,33 @@ final class FavoritesViewController: UIViewController {
         ])
     }
 
+    private func setupEmptyView() {
+        view.addSubview(emptyView)
+        emptyView.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            emptyView.topAnchor.constraint(equalTo: view.topAnchor),
+            emptyView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            emptyView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            emptyView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+    }
+
+    // MARK: - Logic
+
     private func loadFavorites() {
         favorites = FavoritesManager.shared.getFavorites() ?? []
+    }
+
+    private func updateUI() {
+        let isEmpty = favorites.isEmpty
+        emptyView.isHidden = !isEmpty
+        tableView.isHidden = isEmpty
         tableView.reloadData()
     }
 }
 
+// MARK: - UITableViewDataSource, UITableViewDelegate
 extension FavoritesViewController: UITableViewDataSource, UITableViewDelegate {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         favorites.count

--- a/NewsAggregator/Modules/Shared/EmptyStateView.swift
+++ b/NewsAggregator/Modules/Shared/EmptyStateView.swift
@@ -1,0 +1,45 @@
+
+import UIKit
+
+final class EmptyStateView: UIView {
+    private let imageView = UIImageView()
+    private let messageLabel = UILabel()
+    
+    init(message: String, image: UIImage? = UIImage(systemName: "star")) {
+        super.init(frame: .zero)
+        setupUI(message: message, image: image)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupUI(message: String, image: UIImage?) {
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.image = image
+        imageView.tintColor = .secondaryLabel
+        imageView.contentMode = .scaleAspectFit
+        
+        messageLabel.translatesAutoresizingMaskIntoConstraints = false
+        messageLabel.text = message
+        messageLabel.font = .systemFont(ofSize: 16, weight: .medium)
+        messageLabel.textColor = .secondaryLabel
+        messageLabel.textAlignment = .center
+        messageLabel.numberOfLines = 0
+        
+        let stack = UIStackView(arrangedSubviews: [imageView, messageLabel])
+        stack.axis = .vertical
+        stack.spacing = 16
+        stack.alignment = .center
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(stack)
+        
+        NSLayoutConstraint.activate([
+            imageView.heightAnchor.constraint(equalToConstant: 64),
+            imageView.widthAnchor.constraint(equalToConstant: 64),
+            
+            stack.centerXAnchor.constraint(equalTo: centerXAnchor),
+            stack.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ])
+    }
+}

--- a/NewsAggregator/Services/APIService.swift
+++ b/NewsAggregator/Services/APIService.swift
@@ -24,7 +24,7 @@ final class APIService {
         
         let (data, _) = try await URLSession.shared.data(from: url)
         
-        print(String(data: data, encoding: .utf8) ?? "no data")
+//        print(String(data: data, encoding: .utf8) ?? "no data")
 
         let decoded = try JSONDecoder().decode(NewsResponse.self, from: data)
         return decoded.results


### PR DESCRIPTION
## 🎭 Что сделано

Добавлен `EmptyStateView` и отображение пустого состояния во вкладке "Избранное":

- при отсутствии новостей отображается иконка и текст-заглушка
- если появляются избранные — отображается таблица, пустое скрывается
- реализовано через отдельный переиспользуемый `UIView`

---

## Скриншот 


<img  height="600" alt="Simulator Screenshot - iPhone 16 - 2025-07-13 at 00 53 33" src="https://github.com/user-attachments/assets/fb669fcb-d8f3-4bc6-9d05-a1c75cdb86ad" />

---

## 🧪 Как протестировать

1. Очистить избранное (удалить все статьи)
2. Перейти на вкладку **Избранное**
3. Увидеть сообщение "У вас пока нет избранных новостей"
4. Добавить новость → заглушка исчезнет, появится список

---

## 🔗 Связанные тикеты

Closes #13
