### PR TITLE
feat: add search bar to filter news by title

### DIFF
--- a/NewsAggregator/Modules/NewsList/NewsListViewController.swift
+++ b/NewsAggregator/Modules/NewsList/NewsListViewController.swift
@@ -6,6 +6,7 @@ final class NewsListViewController: UIViewController {
     private let tableView = UITableView()
     private let viewModel = NewsListViewModel()
     private let refreshControl = UIRefreshControl()
+    private let searchController = UISearchController(searchResultsController: nil)
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -15,6 +16,10 @@ final class NewsListViewController: UIViewController {
         
         bindViewModel()
         viewModel.fetchNews()
+        navigationItem.searchController = searchController
+        searchController.searchBar.placeholder = "Search..."
+        searchController.obscuresBackgroundDuringPresentation = false
+        searchController.searchBar.delegate = self
     }
     private func setupTableView() {
         view.addSubview(tableView)
@@ -70,5 +75,11 @@ extension NewsListViewController: UITableViewDataSource, UITableViewDelegate {
         let detailVC = NewsDetailViewController(article: article)
         navigationController?.pushViewController(detailVC, animated: true)
         tableView.deselectRow(at: indexPath, animated: true)
+    }
+}
+
+extension NewsListViewController: UISearchBarDelegate {
+    func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
+        viewModel.filter(with: searchText)
     }
 }

--- a/NewsAggregator/Modules/NewsList/NewsListViewModel.swift
+++ b/NewsAggregator/Modules/NewsList/NewsListViewModel.swift
@@ -2,6 +2,7 @@ import Foundation
 
 final class NewsListViewModel {
     private(set) var articles: [NewsArticle] = []
+    private(set) var filteredArticles: [NewsArticle] = []
     
     private var page = 1
     private var isLoading = false
@@ -9,6 +10,8 @@ final class NewsListViewModel {
     
     var onUpdate: (() -> Void)?
     
+    // MARK: - Fetch News (Pagination)
+
     func fetchNews() {
         guard !isLoading, hasMoreData else { return }
 
@@ -22,7 +25,8 @@ final class NewsListViewModel {
                     hasMoreData = false
                 }
 
-                self.articles.append(contentsOf: newArticles)
+                articles.append(contentsOf: newArticles)
+                filteredArticles = articles
                 page += 1
                 isLoading = false
 
@@ -35,18 +39,19 @@ final class NewsListViewModel {
             }
         }
     }
-    
+
     func fetchMoreIfNeeded(currentIndex: Int) {
-        let thresholdIndex = articles.count - 5
+        let thresholdIndex = filteredArticles.count - 5
         if currentIndex >= thresholdIndex {
             fetchNews()
         }
     }
-    
+
+    // MARK: - Pull to Refresh
+
     func refreshNews(completion: @escaping () -> Void) {
         page = 1
         hasMoreData = true
-
         isLoading = true
 
         Task {
@@ -54,6 +59,7 @@ final class NewsListViewModel {
                 let newArticles = try await APIService.shared.fetchNews(page: page)
 
                 articles = newArticles
+                filteredArticles = newArticles
                 page += 1
                 isLoading = false
 
@@ -71,16 +77,29 @@ final class NewsListViewModel {
         }
     }
 
+    // MARK: - Search
 
-    func article(at index: Int) -> NewsArticle {
-        guard index < articles.count else {
-            return NewsArticle(title: "Ошибка", link: nil, pubDate: nil, image_url: nil, description: "Индекс вне диапазона", creator: nil)
+    func filter(with text: String) {
+        if text.isEmpty {
+            filteredArticles = articles
+        } else {
+            filteredArticles = articles.filter {
+                $0.title?.localizedCaseInsensitiveContains(text) == true
+            }
         }
-        return articles[index]
+        onUpdate?()
     }
 
-    
+    // MARK: - Access
+
+    func article(at index: Int) -> NewsArticle {
+        guard index < filteredArticles.count else {
+            return NewsArticle(title: "Ошибка", link: nil, pubDate: nil, image_url: nil, description: "Индекс вне диапазона", creator: nil)
+        }
+        return filteredArticles[index]
+    }
+
     var count: Int {
-        articles.count
+        filteredArticles.count
     }
 }


### PR DESCRIPTION
## 🔍 Что было добавлено

- Реализована строка поиска на экране списка новостей с использованием `UISearchController`
- Добавлена локальная фильтрация новостей по заголовку статьи (`title`)
- Поиск работает без учета регистра (case-insensitive)
- При очистке поисковой строки автоматически восстанавливается полный список статей

## 🧪 Инструкция по тестированию

1. Запустите приложение
2. Введите текст для поиска в появившуюся строку (например: "Apple", "Наука")
3. Убедитесь, что список новостей фильтруется в реальном времени
4. Очистите поисковый запрос - должен восстановиться исходный список новостей

Пример работы:

<img src="https://github.com/user-attachments/assets/e8378502-54a8-425f-9ee6-5fd90e3cec5c" width="400" />


---

## 🔗 Related

Closes #17 
