### PR TITLE
feat: add horizontal Latest News section with collection view

### DIFF
--- a/NewsAggregator.xcodeproj/project.pbxproj
+++ b/NewsAggregator.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		CE27AD0A2E22819D00FECF74 /* FavoritesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE27AD092E22819D00FECF74 /* FavoritesManager.swift */; };
 		CE27AD0C2E228CB200FECF74 /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE27AD0B2E228CB200FECF74 /* ImageLoader.swift */; };
 		CE27AD112E22DF7800FECF74 /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE27AD102E22DF7800FECF74 /* EmptyStateView.swift */; };
+		CE27AD132E2449DB00FECF74 /* LatestNewsCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE27AD122E2449DB00FECF74 /* LatestNewsCollectionViewCell.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -40,6 +41,7 @@
 		CE27AD092E22819D00FECF74 /* FavoritesManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesManager.swift; sourceTree = "<group>"; };
 		CE27AD0B2E228CB200FECF74 /* ImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoader.swift; sourceTree = "<group>"; };
 		CE27AD102E22DF7800FECF74 /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
+		CE27AD122E2449DB00FECF74 /* LatestNewsCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LatestNewsCollectionViewCell.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -167,6 +169,7 @@
 			children = (
 				CE27AD052E21B95200FECF74 /* NewsTableViewCell.swift */,
 				CE27AD102E22DF7800FECF74 /* EmptyStateView.swift */,
+				CE27AD122E2449DB00FECF74 /* LatestNewsCollectionViewCell.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -256,6 +259,7 @@
 				CE27AD082E226A8A00FECF74 /* NewsDetailViewController.swift in Sources */,
 				CE27AD042E21AC7300FECF74 /* NewsListViewModel.swift in Sources */,
 				CE27ACDA2E218A3D00FECF74 /* NewsListViewController.swift in Sources */,
+				CE27AD132E2449DB00FECF74 /* LatestNewsCollectionViewCell.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/NewsAggregator/Modules/NewsList/NewsListViewController.swift
+++ b/NewsAggregator/Modules/NewsList/NewsListViewController.swift
@@ -1,39 +1,62 @@
-
 import UIKit
 
 final class NewsListViewController: UIViewController {
-    
+
+    // MARK: - UI
     private let tableView = UITableView()
-    private let viewModel = NewsListViewModel()
     private let refreshControl = UIRefreshControl()
     private let searchController = UISearchController(searchResultsController: nil)
-    
+    private let viewModel = NewsListViewModel()
+
+    private lazy var latestCollectionView: UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .horizontal
+        layout.itemSize = CGSize(width: 200, height: 160)
+        layout.minimumLineSpacing = 12
+
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        collectionView.backgroundColor = .clear
+        collectionView.showsHorizontalScrollIndicator = false
+        collectionView.dataSource = self
+        collectionView.delegate = self
+        collectionView.register(LatestNewsCollectionViewCell.self, forCellWithReuseIdentifier: LatestNewsCollectionViewCell.identifier)
+        return collectionView
+    }()
+
+    // MARK: - Lifecycle
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .systemBackground
         title = "Новости"
+        view.backgroundColor = .systemBackground
+        setupSearch()
         setupTableView()
-        
+        setupHeader()
         bindViewModel()
         viewModel.fetchNews()
+    }
+
+    // MARK: - Setup
+
+    private func setupSearch() {
         navigationItem.searchController = searchController
-        searchController.searchBar.placeholder = "Search..."
+        searchController.searchBar.placeholder = "Поиск"
         searchController.obscuresBackgroundDuringPresentation = false
         searchController.searchBar.delegate = self
     }
+
     private func setupTableView() {
         view.addSubview(tableView)
         tableView.translatesAutoresizingMaskIntoConstraints = false
-        tableView.dataSource = self
-        tableView.delegate = self
-        tableView.register(NewsTableViewCell.self, forCellReuseIdentifier: NewsTableViewCell.identifier)
-        
         tableView.refreshControl = refreshControl
         refreshControl.addTarget(self, action: #selector(refreshNews), for: .valueChanged)
-        
+
+        tableView.delegate = self
+        tableView.dataSource = self
+        tableView.register(NewsTableViewCell.self, forCellReuseIdentifier: NewsTableViewCell.identifier)
         tableView.estimatedRowHeight = 100
         tableView.rowHeight = UITableView.automaticDimension
-        
+
         NSLayoutConstraint.activate([
             tableView.topAnchor.constraint(equalTo: view.topAnchor),
             tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
@@ -41,25 +64,53 @@ final class NewsListViewController: UIViewController {
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])
     }
-    
-    private func bindViewModel() {
-        viewModel.onUpdate = { [weak self] in
-            self?.tableView.reloadData()
-        }
+
+    private func setupHeader() {
+        let headerContainer = UIView()
+        headerContainer.addSubview(latestCollectionView)
+
+        latestCollectionView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            latestCollectionView.topAnchor.constraint(equalTo: headerContainer.topAnchor, constant: 16),
+            latestCollectionView.leadingAnchor.constraint(equalTo: headerContainer.leadingAnchor, constant: 16),
+            latestCollectionView.trailingAnchor.constraint(equalTo: headerContainer.trailingAnchor, constant: -16),
+            latestCollectionView.heightAnchor.constraint(equalToConstant: 180),
+            latestCollectionView.bottomAnchor.constraint(equalTo: headerContainer.bottomAnchor, constant: -16)
+        ])
+
+        // 👇 Это важно
+        let targetWidth = view.bounds.width
+        let targetHeight: CGFloat = 212
+
+        headerContainer.frame = CGRect(x: 0, y: 0, width: targetWidth, height: targetHeight)
+        headerContainer.layoutIfNeeded() // ⚠️ ОБЯЗАТЕЛЬНО: применяет constraints
+
+        tableView.tableHeaderView = headerContainer
     }
-    
+
+
+    // MARK: - Logic
+
     @objc private func refreshNews() {
         viewModel.refreshNews {
             self.refreshControl.endRefreshing()
         }
     }
+
+    private func bindViewModel() {
+        viewModel.onUpdate = { [weak self] in
+            self?.tableView.reloadData()
+            self?.latestCollectionView.reloadData()
+        }
+    }
 }
 
+// MARK: - TableView
 extension NewsListViewController: UITableViewDataSource, UITableViewDelegate {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         viewModel.count
     }
-    
+
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let article = viewModel.article(at: indexPath.row)
         guard let cell = tableView.dequeueReusableCell(withIdentifier: NewsTableViewCell.identifier, for: indexPath) as? NewsTableViewCell else {
@@ -69,17 +120,40 @@ extension NewsListViewController: UITableViewDataSource, UITableViewDelegate {
         viewModel.fetchMoreIfNeeded(currentIndex: indexPath.row)
         return cell
     }
-    
+
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let article = viewModel.article(at: indexPath.row)
-        let detailVC = NewsDetailViewController(article: article)
-        navigationController?.pushViewController(detailVC, animated: true)
+        let vc = NewsDetailViewController(article: article)
+        navigationController?.pushViewController(vc, animated: true)
         tableView.deselectRow(at: indexPath, animated: true)
     }
 }
 
+// MARK: - Search
 extension NewsListViewController: UISearchBarDelegate {
     func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
         viewModel.filter(with: searchText)
+    }
+}
+
+// MARK: - CollectionView
+extension NewsListViewController: UICollectionViewDataSource, UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        min(viewModel.count, 10)
+    }
+
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: LatestNewsCollectionViewCell.identifier, for: indexPath) as? LatestNewsCollectionViewCell else {
+            return UICollectionViewCell()
+        }
+        let article = viewModel.article(at: indexPath.row)
+        cell.configure(with: article)
+        return cell
+    }
+
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        let article = viewModel.article(at: indexPath.row)
+        let vc = NewsDetailViewController(article: article)
+        navigationController?.pushViewController(vc, animated: true)
     }
 }

--- a/NewsAggregator/Modules/Shared/LatestNewsCollectionViewCell.swift
+++ b/NewsAggregator/Modules/Shared/LatestNewsCollectionViewCell.swift
@@ -1,0 +1,53 @@
+import UIKit
+
+class LatestNewsCollectionViewCell: UICollectionViewCell {
+    static let identifier = "LatestNewsCollectionViewCell"
+
+    private let imageView = UIImageView()
+    private let titleLabel = UILabel()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        contentView.backgroundColor = .secondarySystemBackground
+        contentView.layer.cornerRadius = 12
+        contentView.clipsToBounds = true
+
+        imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+
+        titleLabel.font = .systemFont(ofSize: 14, weight: .semibold)
+        titleLabel.numberOfLines = 2
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        contentView.addSubview(imageView)
+        contentView.addSubview(titleLabel)
+
+        NSLayoutConstraint.activate([
+            imageView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            imageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            imageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            imageView.heightAnchor.constraint(equalToConstant: 100),
+
+            titleLabel.topAnchor.constraint(equalTo: imageView.bottomAnchor, constant: 8),
+            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 8),
+            titleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -8),
+            titleLabel.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor, constant: -8)
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(with article: NewsArticle) {
+        titleLabel.text = article.title
+        if let urlString = article.image_url, let url = URL(string: urlString) {
+            ImageLoader.shared.loadImage(from: url) { [weak self] image in
+                self?.imageView.image = image
+            }
+        } else {
+            imageView.image = UIImage(systemName: "photo")
+        }
+    }
+}


### PR DESCRIPTION
## 🖼 Что сделано

- Добавлен горизонтальный блок **"Последние новости"** (`UICollectionView`)
- Блок встроен в верхнюю часть экрана (`tableHeaderView`)
- Каждая ячейка отображает:
  - Картинку (если есть)
  - Заголовок (2 строки)
- Отображаются до **10 последних статей**
- При нажатии открывается экран с деталями новости

---

## 🔧 Технические детали

- Используется `UICollectionViewFlowLayout` с горизонтальной прокруткой
- Кастомная ячейка `LatestNewsCollectionViewCell`
- Коллекция встроена в `UIView`, который установлен как `tableHeaderView`
- Для корректного отображения используется `layoutIfNeeded()`

---

## 🧪 Как протестировать

1. Запустить приложение
2. На экране списка новостей увидеть верхний горизонтальный блок
3. Убедиться, что:
   - Загружаются актуальные заголовки и изображения
   - Работает горизонтальный скролл
   - По нажатию открывается экран с новостью
4. Потянуть вниз для обновления — блок тоже обновляется

---

## 📸 Скриншот

<img src="https://github.com/user-attachments/assets/a71d574e-9a7a-4b82-80af-74249dbdd22b" height="400" />

---

## 📌 Дополнительно

- Используется тот же источник данных, что и в таблице
- Позже можно будет сортировать отдельно или заменить источником `"top headlines"`

---

## 🔗 Связанные тикеты

Closes #18
