### PR TITLE
feat: create 'Latest News' section in main VC

### DIFF
--- a/NewsAggregator.xcodeproj/project.pbxproj
+++ b/NewsAggregator.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		CE27AD0C2E228CB200FECF74 /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE27AD0B2E228CB200FECF74 /* ImageLoader.swift */; };
 		CE27AD112E22DF7800FECF74 /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE27AD102E22DF7800FECF74 /* EmptyStateView.swift */; };
 		CE27AD132E2449DB00FECF74 /* LatestNewsCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE27AD122E2449DB00FECF74 /* LatestNewsCollectionViewCell.swift */; };
+		CECFA83D2E24650C0093855C /* CategoriesFilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CECFA83C2E24650C0093855C /* CategoriesFilterView.swift */; };
+		CECFA83F2E2465350093855C /* CategoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CECFA83E2E2465350093855C /* CategoryCell.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -42,6 +44,8 @@
 		CE27AD0B2E228CB200FECF74 /* ImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoader.swift; sourceTree = "<group>"; };
 		CE27AD102E22DF7800FECF74 /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
 		CE27AD122E2449DB00FECF74 /* LatestNewsCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LatestNewsCollectionViewCell.swift; sourceTree = "<group>"; };
+		CECFA83C2E24650C0093855C /* CategoriesFilterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoriesFilterView.swift; sourceTree = "<group>"; };
+		CECFA83E2E2465350093855C /* CategoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryCell.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -170,6 +174,8 @@
 				CE27AD052E21B95200FECF74 /* NewsTableViewCell.swift */,
 				CE27AD102E22DF7800FECF74 /* EmptyStateView.swift */,
 				CE27AD122E2449DB00FECF74 /* LatestNewsCollectionViewCell.swift */,
+				CECFA83C2E24650C0093855C /* CategoriesFilterView.swift */,
+				CECFA83E2E2465350093855C /* CategoryCell.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -253,6 +259,7 @@
 				CE27AD062E21B95200FECF74 /* NewsTableViewCell.swift in Sources */,
 				CE27ACCD2E217F0400FECF74 /* SceneDelegate.swift in Sources */,
 				CE27AD0C2E228CB200FECF74 /* ImageLoader.swift in Sources */,
+				CECFA83D2E24650C0093855C /* CategoriesFilterView.swift in Sources */,
 				CE27AD112E22DF7800FECF74 /* EmptyStateView.swift in Sources */,
 				CE27ACDC2E218B2E00FECF74 /* FavoritesViewController.swift in Sources */,
 				CE27ACDE2E218B7A00FECF74 /* APIService.swift in Sources */,
@@ -260,6 +267,7 @@
 				CE27AD042E21AC7300FECF74 /* NewsListViewModel.swift in Sources */,
 				CE27ACDA2E218A3D00FECF74 /* NewsListViewController.swift in Sources */,
 				CE27AD132E2449DB00FECF74 /* LatestNewsCollectionViewCell.swift in Sources */,
+				CECFA83F2E2465350093855C /* CategoryCell.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/NewsAggregator/Modules/NewsList/NewsListViewController.swift
+++ b/NewsAggregator/Modules/NewsList/NewsListViewController.swift
@@ -1,19 +1,21 @@
 import UIKit
 
 final class NewsListViewController: UIViewController {
-
+    
     // MARK: - UI
     private let tableView = UITableView()
     private let refreshControl = UIRefreshControl()
+    private let activityIndicator = UIActivityIndicatorView(style: .medium)
     private let searchController = UISearchController(searchResultsController: nil)
+    private let categoriesView = CategoriesFilterView()
     private let viewModel = NewsListViewModel()
-
+    
     private lazy var latestCollectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
         layout.itemSize = CGSize(width: 200, height: 160)
         layout.minimumLineSpacing = 12
-
+        
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.backgroundColor = .clear
         collectionView.showsHorizontalScrollIndicator = false
@@ -22,9 +24,9 @@ final class NewsListViewController: UIViewController {
         collectionView.register(LatestNewsCollectionViewCell.self, forCellWithReuseIdentifier: LatestNewsCollectionViewCell.identifier)
         return collectionView
     }()
-
+    
     // MARK: - Lifecycle
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "Новости"
@@ -35,28 +37,28 @@ final class NewsListViewController: UIViewController {
         bindViewModel()
         viewModel.fetchNews()
     }
-
+    
     // MARK: - Setup
-
+    
     private func setupSearch() {
         navigationItem.searchController = searchController
         searchController.searchBar.placeholder = "Поиск"
         searchController.obscuresBackgroundDuringPresentation = false
         searchController.searchBar.delegate = self
     }
-
+    
     private func setupTableView() {
         view.addSubview(tableView)
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.refreshControl = refreshControl
         refreshControl.addTarget(self, action: #selector(refreshNews), for: .valueChanged)
-
+        
         tableView.delegate = self
         tableView.dataSource = self
         tableView.register(NewsTableViewCell.self, forCellReuseIdentifier: NewsTableViewCell.identifier)
         tableView.estimatedRowHeight = 100
         tableView.rowHeight = UITableView.automaticDimension
-
+        
         NSLayoutConstraint.activate([
             tableView.topAnchor.constraint(equalTo: view.topAnchor),
             tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
@@ -64,43 +66,71 @@ final class NewsListViewController: UIViewController {
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])
     }
-
+    
     private func setupHeader() {
         let headerContainer = UIView()
+
+        let latestLabel = UILabel()
+        latestLabel.text = "Последние новости"
+        latestLabel.font = .boldSystemFont(ofSize: 20)
+        latestLabel.translatesAutoresizingMaskIntoConstraints = false
+        headerContainer.addSubview(activityIndicator)
+        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
+        headerContainer.addSubview(latestLabel)
         headerContainer.addSubview(latestCollectionView)
+        headerContainer.addSubview(categoriesView)
 
         latestCollectionView.translatesAutoresizingMaskIntoConstraints = false
+        categoriesView.translatesAutoresizingMaskIntoConstraints = false
+
         NSLayoutConstraint.activate([
-            latestCollectionView.topAnchor.constraint(equalTo: headerContainer.topAnchor, constant: 16),
+            latestLabel.topAnchor.constraint(equalTo: headerContainer.topAnchor, constant: 16),
+            latestLabel.leadingAnchor.constraint(equalTo: headerContainer.leadingAnchor, constant: 16),
+            latestLabel.trailingAnchor.constraint(equalTo: headerContainer.trailingAnchor, constant: -16),
+
+            latestCollectionView.topAnchor.constraint(equalTo: latestLabel.bottomAnchor, constant: 8),
             latestCollectionView.leadingAnchor.constraint(equalTo: headerContainer.leadingAnchor, constant: 16),
             latestCollectionView.trailingAnchor.constraint(equalTo: headerContainer.trailingAnchor, constant: -16),
             latestCollectionView.heightAnchor.constraint(equalToConstant: 180),
-            latestCollectionView.bottomAnchor.constraint(equalTo: headerContainer.bottomAnchor, constant: -16)
+
+            categoriesView.topAnchor.constraint(equalTo: latestCollectionView.bottomAnchor, constant: 12),
+            categoriesView.leadingAnchor.constraint(equalTo: headerContainer.leadingAnchor),
+            categoriesView.trailingAnchor.constraint(equalTo: headerContainer.trailingAnchor),
+            categoriesView.heightAnchor.constraint(equalToConstant: 40),
+            categoriesView.bottomAnchor.constraint(equalTo: headerContainer.bottomAnchor, constant: -12),
+            
+            activityIndicator.topAnchor.constraint(equalTo: categoriesView.bottomAnchor, constant: 8),
+            activityIndicator.centerXAnchor.constraint(equalTo: headerContainer.centerXAnchor)
         ])
 
-        // 👇 Это важно
-        let targetWidth = view.bounds.width
-        let targetHeight: CGFloat = 212
-
-        headerContainer.frame = CGRect(x: 0, y: 0, width: targetWidth, height: targetHeight)
-        headerContainer.layoutIfNeeded() // ⚠️ ОБЯЗАТЕЛЬНО: применяет constraints
+        // 👇 Размер header-а (нужен для tableHeaderView)
+        let totalHeight: CGFloat = 16 + 24 + 8 + 180 + 12 + 40 + 12
+        headerContainer.frame = CGRect(x: 0, y: 0, width: view.bounds.width, height: totalHeight)
+        headerContainer.layoutIfNeeded()
 
         tableView.tableHeaderView = headerContainer
+
+        // Категории и делегат
+        categoriesView.categories = viewModel.categories
+        categoriesView.delegate = self
     }
 
-
+    
+    
     // MARK: - Logic
-
+    
     @objc private func refreshNews() {
         viewModel.refreshNews {
             self.refreshControl.endRefreshing()
         }
     }
-
+    
     private func bindViewModel() {
         viewModel.onUpdate = { [weak self] in
-            self?.tableView.reloadData()
-            self?.latestCollectionView.reloadData()
+            guard let self = self else { return }
+            self.tableView.reloadData()
+            self.latestCollectionView.reloadData()
+            self.activityIndicator.stopAnimating()
         }
     }
 }
@@ -110,7 +140,7 @@ extension NewsListViewController: UITableViewDataSource, UITableViewDelegate {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         viewModel.count
     }
-
+    
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let article = viewModel.article(at: indexPath.row)
         guard let cell = tableView.dequeueReusableCell(withIdentifier: NewsTableViewCell.identifier, for: indexPath) as? NewsTableViewCell else {
@@ -120,7 +150,7 @@ extension NewsListViewController: UITableViewDataSource, UITableViewDelegate {
         viewModel.fetchMoreIfNeeded(currentIndex: indexPath.row)
         return cell
     }
-
+    
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let article = viewModel.article(at: indexPath.row)
         let vc = NewsDetailViewController(article: article)
@@ -139,21 +169,28 @@ extension NewsListViewController: UISearchBarDelegate {
 // MARK: - CollectionView
 extension NewsListViewController: UICollectionViewDataSource, UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        min(viewModel.count, 10)
+        return min(viewModel.latestCount, 10)
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: LatestNewsCollectionViewCell.identifier, for: indexPath) as? LatestNewsCollectionViewCell else {
             return UICollectionViewCell()
         }
-        let article = viewModel.article(at: indexPath.row)
+        let article = viewModel.latestArticle(at: indexPath.item)
         cell.configure(with: article)
         return cell
     }
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let article = viewModel.article(at: indexPath.row)
+        let article = viewModel.latestArticle(at: indexPath.item)
         let vc = NewsDetailViewController(article: article)
         navigationController?.pushViewController(vc, animated: true)
+    }
+}
+
+extension NewsListViewController: CategoriesFilterViewDelegate {
+    func didSelectCategory(key: String?) {
+        activityIndicator.startAnimating()
+        viewModel.setCategory(key)
     }
 }

--- a/NewsAggregator/Modules/NewsList/NewsListViewModel.swift
+++ b/NewsAggregator/Modules/NewsList/NewsListViewModel.swift
@@ -1,83 +1,51 @@
 import Foundation
 
 final class NewsListViewModel {
+
+    // MARK: - Public
+
+    let categories: [(title: String, key: String?)] = [
+        ("Все", nil),
+        ("Наука", "science"),
+        ("Здоровье", "health"),
+        ("Культура", "entertainment"),
+        ("Бизнес", "business")
+    ]
+
     private(set) var articles: [NewsArticle] = []
     private(set) var filteredArticles: [NewsArticle] = []
-    
+    private(set) var latestArticles: [NewsArticle] = []
+
+    var onUpdate: (() -> Void)?
+
+    // MARK: - Private
+
+    private var currentCategory: String? = nil
     private var page = 1
     private var isLoading = false
     private var hasMoreData = true
-    
-    var onUpdate: (() -> Void)?
-    
-    // MARK: - Fetch News (Pagination)
+
+    // MARK: - Public Methods
 
     func fetchNews() {
-        guard !isLoading, hasMoreData else { return }
+        loadNews()
+    }
 
-        isLoading = true
-
-        Task {
-            do {
-                let newArticles = try await APIService.shared.fetchNews(page: page)
-
-                if newArticles.isEmpty {
-                    hasMoreData = false
-                }
-
-                articles.append(contentsOf: newArticles)
-                filteredArticles = articles
-                page += 1
-                isLoading = false
-
-                DispatchQueue.main.async {
-                    self.onUpdate?()
-                }
-            } catch {
-                isLoading = false
-                print("Ошибка при получении новостей:", error)
-            }
-        }
+    func refreshNews(completion: @escaping () -> Void) {
+        loadNews(reset: true, completion: completion)
     }
 
     func fetchMoreIfNeeded(currentIndex: Int) {
         let thresholdIndex = filteredArticles.count - 5
         if currentIndex >= thresholdIndex {
-            fetchNews()
+            loadNews()
         }
     }
 
-    // MARK: - Pull to Refresh
-
-    func refreshNews(completion: @escaping () -> Void) {
-        page = 1
-        hasMoreData = true
-        isLoading = true
-
-        Task {
-            do {
-                let newArticles = try await APIService.shared.fetchNews(page: page)
-
-                articles = newArticles
-                filteredArticles = newArticles
-                page += 1
-                isLoading = false
-
-                DispatchQueue.main.async {
-                    self.onUpdate?()
-                    completion()
-                }
-            } catch {
-                isLoading = false
-                print("Ошибка при обновлении новостей:", error)
-                DispatchQueue.main.async {
-                    completion()
-                }
-            }
-        }
+    func setCategory(_ category: String?) {
+        currentCategory = category
+        loadNews(reset: true)
     }
-
-    // MARK: - Search
 
     func filter(with text: String) {
         if text.isEmpty {
@@ -90,8 +58,6 @@ final class NewsListViewModel {
         onUpdate?()
     }
 
-    // MARK: - Access
-
     func article(at index: Int) -> NewsArticle {
         guard index < filteredArticles.count else {
             return NewsArticle(title: "Ошибка", link: nil, pubDate: nil, image_url: nil, description: "Индекс вне диапазона", creator: nil)
@@ -101,5 +67,67 @@ final class NewsListViewModel {
 
     var count: Int {
         filteredArticles.count
+    }
+    
+    func latestArticle(at index: Int) -> NewsArticle {
+        guard index < latestArticles.count else {
+            return NewsArticle(title: "Ошибка", link: nil, pubDate: nil, image_url: nil, description: "Индекс вне диапазона", creator: nil)
+        }
+        return latestArticles[index]
+    }
+
+    var latestCount: Int {
+        latestArticles.count
+    }
+
+
+    // MARK: - Private Methods
+
+    private func loadNews(reset: Bool = false, completion: (() -> Void)? = nil) {
+        if reset {
+            page = 1
+            hasMoreData = true
+            articles = []
+            filteredArticles = []
+            onUpdate?()
+        }
+
+        guard !isLoading, hasMoreData else {
+            completion?()
+            return
+        }
+
+        isLoading = true
+
+        Task {
+            do {
+                let newArticles = try await APIService.shared.fetchNews(page: page, category: currentCategory)
+                
+                if reset && currentCategory == nil {
+                    latestArticles = newArticles
+                }
+
+                if newArticles.isEmpty {
+                    hasMoreData = false
+                }
+
+                articles.append(contentsOf: newArticles)
+                filteredArticles = articles
+                page += 1
+
+                DispatchQueue.main.async {
+                    self.onUpdate?()
+                    completion?()
+                }
+
+            } catch {
+                print("❌ Ошибка при загрузке новостей:", error)
+                DispatchQueue.main.async {
+                    completion?()
+                }
+            }
+
+            isLoading = false
+        }
     }
 }

--- a/NewsAggregator/Modules/Shared/CategoriesFilterView.swift
+++ b/NewsAggregator/Modules/Shared/CategoriesFilterView.swift
@@ -1,0 +1,97 @@
+import UIKit
+
+protocol CategoriesFilterViewDelegate: AnyObject {
+    func didSelectCategory(key: String?)
+}
+
+final class CategoriesFilterView: UIView {
+    
+    var categories: [(title: String, key: String?)] = [] {
+        didSet {
+            selectedIndex = 0
+            collectionView.reloadData()
+        }
+    }
+    
+    weak var delegate: CategoriesFilterViewDelegate?
+    
+    private var selectedIndex: Int = 0
+    
+    private lazy var collectionView: UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .horizontal
+        layout.minimumLineSpacing = 8
+        layout.sectionInset = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
+        
+        let collection = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        collection.backgroundColor = .clear
+        collection.showsHorizontalScrollIndicator = false
+        collection.delegate = self
+        collection.dataSource = self
+        collection.register(CategoryCell.self, forCellWithReuseIdentifier: CategoryCell.identifier)
+        collection.translatesAutoresizingMaskIntoConstraints = false
+        return collection
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupLayout() {
+        addSubview(collectionView)
+        
+        NSLayoutConstraint.activate([
+            collectionView.topAnchor.constraint(equalTo: topAnchor),
+            collectionView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            collectionView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            collectionView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            collectionView.heightAnchor.constraint(equalToConstant: 40)
+        ])
+    }
+}
+
+// MARK: - UICollectionViewDataSource & Delegate
+
+extension CategoriesFilterView: UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        categories.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CategoryCell.identifier, for: indexPath) as? CategoryCell else {
+            return UICollectionViewCell()
+        }
+        
+        let category = categories[indexPath.item]
+        let isSelected = indexPath.item == selectedIndex
+        cell.configure(title: category.title, isSelected: isSelected)
+        return cell
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard indexPath.item != selectedIndex else { return }
+        
+        selectedIndex = indexPath.item
+        collectionView.reloadData()
+        
+        let selectedCategoryKey = categories[selectedIndex].key
+        delegate?.didSelectCategory(key: selectedCategoryKey)
+    }
+    
+    // ✅ Вот ключ: расчёт ширины по содержимому
+    func collectionView(_ collectionView: UICollectionView,
+                        layout collectionViewLayout: UICollectionViewLayout,
+                        sizeForItemAt indexPath: IndexPath) -> CGSize {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 14, weight: .medium)
+        label.text = categories[indexPath.item].title
+        let targetSize = CGSize(width: UIView.layoutFittingCompressedSize.width, height: 32)
+        let width = label.systemLayoutSizeFitting(targetSize).width + 24 // padding
+        return CGSize(width: width, height: 32)
+    }
+}

--- a/NewsAggregator/Modules/Shared/CategoryCell.swift
+++ b/NewsAggregator/Modules/Shared/CategoryCell.swift
@@ -1,0 +1,39 @@
+import UIKit
+
+final class CategoryCell: UICollectionViewCell {
+    static let identifier = "CategoryCell"
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 14, weight: .medium)
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        contentView.addSubview(titleLabel)
+        contentView.backgroundColor = .systemGray5
+        contentView.layer.cornerRadius = 16
+        contentView.clipsToBounds = true
+
+        NSLayoutConstraint.activate([
+            titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 6),
+            titleLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -6),
+            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 12),
+            titleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -12)
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(title: String, isSelected: Bool) {
+        titleLabel.text = title
+        contentView.backgroundColor = isSelected ? .systemBlue : .systemGray5
+        titleLabel.textColor = isSelected ? .white : .label
+    }
+}

--- a/NewsAggregator/Services/APIService.swift
+++ b/NewsAggregator/Services/APIService.swift
@@ -7,26 +7,29 @@ final class APIService {
     
     private init() {}
     
-    func fetchNews(page: Int = 1) async throws -> [NewsArticle] {
+    func fetchNews(page: Int = 1, category: String? = nil) async throws -> [NewsArticle] {
         guard var urlComponents = URLComponents(string: baseURL) else {
             throw URLError(.badURL)
         }
-        
-        urlComponents.queryItems = [
+
+        var queryItems = [
             URLQueryItem(name: "apikey", value: apiKey),
-            URLQueryItem(name: "language", value: "ru"),
-//            URLQueryItem(name: "page", value: String(page))
+            URLQueryItem(name: "language", value: "ru")
         ]
-        
+
+        if let category = category {
+            queryItems.append(URLQueryItem(name: "category", value: category))
+        }
+
+        urlComponents.queryItems = queryItems
+
         guard let url = urlComponents.url else {
             throw URLError(.badURL)
         }
-        
-        let (data, _) = try await URLSession.shared.data(from: url)
-        
-//        print(String(data: data, encoding: .utf8) ?? "no data")
 
+        let (data, _) = try await URLSession.shared.data(from: url)
         let decoded = try JSONDecoder().decode(NewsResponse.self, from: data)
         return decoded.results
     }
+
 }


### PR DESCRIPTION
## 🖼 Что сделано

- "Последние новости" (`LatestNewsCollectionView`) теперь **отображает только свежие статьи**, независимо от выбранной категории.
- Добавлен новый массив `latestArticles` в `NewsListViewModel`
- `latestCollectionView` теперь использует `latestArticles`, а не `filteredArticles`
- `UITableView` фильтруется по категориям, `UICollectionView` — всегда показывает 10 самых свежих статей
- Улучшен UX: добавлен `activityIndicator` на время загрузки

## 🧠 Почему это важно

Ранее при выборе категории очищались все статьи, включая последние. Это приводило к пустой карусели. Теперь секция последних новостей независима от фильтра.

## 🖼 Скриншот

<img src="https://github.com/user-attachments/assets/18b054ee-89e9-4aba-86ee-45bac7ba3447" width="300" />


## 🔧 Технические детали

- `latestArticles` заполняется при первой загрузке (категория == nil и reset == true)
- Добавлены методы `latestArticle(at:)` и `latestCount` в `NewsListViewModel`
- Обновлён `UICollectionViewDataSource` в `NewsListViewController`

## 🧪 Как протестировать

1. Запустить приложение
2. Убедиться, что верхняя карусель всегда содержит 10 свежих новостей
3. Выбрать любую категорию — `UITableView` обновится, а `UICollectionView` останется неизменным
4. Нажать на карточку в карусели — открывается экран детали

## 📌 Дополнительно

- Добавлен плавный `UIActivityIndicator` при смене категории
- Заголовок "Последние новости" теперь фиксирован
- Кнопки категорий адаптируются по ширине текста

## 🔗 Связанные тикеты

Closes #18 
