### PR TITLE
refarctor: remove category badge from news list cell

### DIFF
--- a/NewsAggregator/Models/NewsArticle.swift
+++ b/NewsAggregator/Models/NewsArticle.swift
@@ -12,4 +12,5 @@ struct NewsArticle: Codable, Equatable, Hashable {
     let image_url: String?
     let description: String?
     let creator: [String]?
+    let keywords: [String]?
 }

--- a/NewsAggregator/Modules/NewsList/NewsListViewModel.swift
+++ b/NewsAggregator/Modules/NewsList/NewsListViewModel.swift
@@ -60,7 +60,7 @@ final class NewsListViewModel {
 
     func article(at index: Int) -> NewsArticle {
         guard index < filteredArticles.count else {
-            return NewsArticle(title: "Ошибка", link: nil, pubDate: nil, image_url: nil, description: "Индекс вне диапазона", creator: nil)
+            return NewsArticle(title: "Ошибка", link: nil, pubDate: nil, image_url: nil, description: "Индекс вне диапазона", creator: nil, keywords: nil)
         }
         return filteredArticles[index]
     }
@@ -71,7 +71,7 @@ final class NewsListViewModel {
     
     func latestArticle(at index: Int) -> NewsArticle {
         guard index < latestArticles.count else {
-            return NewsArticle(title: "Ошибка", link: nil, pubDate: nil, image_url: nil, description: "Индекс вне диапазона", creator: nil)
+            return NewsArticle(title: "Ошибка", link: nil, pubDate: nil, image_url: nil, description: "Индекс вне диапазона", creator: nil, keywords: nil)
         }
         return latestArticles[index]
     }

--- a/NewsAggregator/Modules/Shared/NewsTableViewCell.swift
+++ b/NewsAggregator/Modules/Shared/NewsTableViewCell.swift
@@ -1,43 +1,45 @@
 import UIKit
 
 final class NewsTableViewCell: UITableViewCell {
-    
+
     static let identifier = "NewsTableViewCell"
 
     private let thumbnailImageView: UIImageView = {
-        let imageView = UIImageView()
-        imageView.contentMode = .scaleAspectFill
-        imageView.layer.cornerRadius = 8
-        imageView.clipsToBounds = true
-        imageView.translatesAutoresizingMaskIntoConstraints = false
-        imageView.backgroundColor = .secondarySystemBackground
-        return imageView
+        let iv = UIImageView()
+        iv.contentMode = .scaleAspectFill
+        iv.layer.cornerRadius = 8
+        iv.clipsToBounds = true
+        iv.translatesAutoresizingMaskIntoConstraints = false
+        iv.backgroundColor = .secondarySystemBackground
+        iv.widthAnchor.constraint(equalToConstant: 80).isActive = true
+        iv.heightAnchor.constraint(equalToConstant: 80).isActive = true
+        return iv
     }()
 
     private let titleLabel: UILabel = {
         let label = UILabel()
-        label.font = UIFont.boldSystemFont(ofSize: 16)
+        label.font = .boldSystemFont(ofSize: 16)
         label.numberOfLines = 2
-        label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
 
-    private let authorLabel: UILabel = {
+    private let metaLabel: UILabel = {
         let label = UILabel()
-        label.font = UIFont.systemFont(ofSize: 12)
+        label.font = .systemFont(ofSize: 12)
         label.textColor = .secondaryLabel
-        label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
 
     private let descriptionLabel: UILabel = {
         let label = UILabel()
-        label.font = UIFont.systemFont(ofSize: 14)
-        label.numberOfLines = 3
+        label.font = .systemFont(ofSize: 14)
         label.textColor = .label
-        label.translatesAutoresizingMaskIntoConstraints = false
+        label.numberOfLines = 2
         return label
     }()
+
+    private let rightStack = UIStackView()
+    private let mainStack = UIStackView()
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -49,45 +51,51 @@ final class NewsTableViewCell: UITableViewCell {
     }
 
     private func setupLayout() {
-        contentView.addSubview(thumbnailImageView)
-        contentView.addSubview(titleLabel)
-        contentView.addSubview(authorLabel)
-        contentView.addSubview(descriptionLabel)
+        rightStack.axis = .vertical
+        rightStack.spacing = 6
+        rightStack.translatesAutoresizingMaskIntoConstraints = false
+        rightStack.addArrangedSubview(titleLabel)
+        rightStack.addArrangedSubview(metaLabel)
+        rightStack.addArrangedSubview(descriptionLabel)
+
+        mainStack.axis = .horizontal
+        mainStack.spacing = 12
+        mainStack.alignment = .top
+        mainStack.translatesAutoresizingMaskIntoConstraints = false
+        mainStack.addArrangedSubview(thumbnailImageView)
+        mainStack.addArrangedSubview(rightStack)
+
+        contentView.addSubview(mainStack)
 
         NSLayoutConstraint.activate([
-            thumbnailImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 12),
-            thumbnailImageView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 12),
-            thumbnailImageView.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor, constant: -12),
-            thumbnailImageView.widthAnchor.constraint(equalToConstant: 80),
-            thumbnailImageView.heightAnchor.constraint(equalToConstant: 80),
-
-            titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 12),
-            titleLabel.leadingAnchor.constraint(equalTo: thumbnailImageView.trailingAnchor, constant: 12),
-            titleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -12),
-
-            authorLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 4),
-            authorLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
-            authorLabel.trailingAnchor.constraint(equalTo: titleLabel.trailingAnchor),
-
-            descriptionLabel.topAnchor.constraint(equalTo: authorLabel.bottomAnchor, constant: 6),
-            descriptionLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
-            descriptionLabel.trailingAnchor.constraint(equalTo: titleLabel.trailingAnchor),
-            descriptionLabel.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor, constant: -12)
+            mainStack.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 12),
+            mainStack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            mainStack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+            mainStack.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor, constant: -12)
         ])
     }
 
     func configure(with article: NewsArticle) {
         titleLabel.text = article.title
-        authorLabel.text = article.creator?.first ?? "Неизвестный автор"
         descriptionLabel.text = article.description
+        metaLabel.text = formatMeta(author: article.creator?.first, date: article.pubDate)
 
-        if let imageURLString = article.image_url,
-           let url = URL(string: imageURLString) {
+        if let urlStr = article.image_url, let url = URL(string: urlStr) {
             ImageLoader.shared.loadImage(from: url) { [weak self] image in
                 self?.thumbnailImageView.image = image ?? UIImage(systemName: "photo")
             }
         } else {
             thumbnailImageView.image = UIImage(systemName: "photo")
         }
+    }
+
+    private func formatMeta(author: String?, date: String?) -> String {
+        var parts: [String] = []
+        if let author = author { parts.append(author) }
+        if let date = date {
+            let formatted = DateFormatter.localizedString(from: ISO8601DateFormatter().date(from: date) ?? Date(), dateStyle: .medium, timeStyle: .none)
+            parts.append(formatted)
+        }
+        return parts.joined(separator: " • ")
     }
 }


### PR DESCRIPTION
## 🎨 Что сделано

- Удалён бейдж категории (`categoryLabel`) из вертикального списка новостей (`NewsTableViewCell`)
- Обновлён layout:
  - Ячейка стала чище: теперь отображается только изображение, заголовок, автор/дата и описание
- Упрощён метод `configure(with:)`

## 🤔 Зачем это нужно

Категории теперь задаются через фильтр сверху. Дублирование их в каждой ячейке создавало визуальный шум и не несло ценности.

## 🧪 Как протестировать

1. Запустить приложение
2. Убедиться, что:
   - В списке новостей отображаются: изображение, заголовок, автор/дата и описание
   - Бейдж с категорией отсутствует
3. Фильтрация по категориям по-прежнему работает через верхние кнопки

## 🔗 Связанные тикеты

closes #20 
